### PR TITLE
Using payloadlen struct field as array size for payload binary daya

### DIFF
--- a/vapi/libmosquitto.vapi
+++ b/vapi/libmosquitto.vapi
@@ -168,7 +168,8 @@ namespace Mosquitto {
     public struct Message {
         int mid;
         string topic;
-        string payload; /* Should be uint8[] but valac generates a non existent payload length */
+        [CCode (array_length_cname = "payloadlen", array_length_type = "size_t")]
+        uint8[] payload;
         int payloadlen;
         int qos;
         bool retain;


### PR DESCRIPTION
Tried it today, it seems it works well :) I can fetch binary data on MQTT topic and its size seems valid. Could you please check at your end? I'm working on a private project with your mappings and this would improve my work much :) Thanks in advance.